### PR TITLE
Fix CLI URLs

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -363,7 +363,7 @@ landscape:
               The CA Endevor® SCM Plug-in for Zowe CLI lets you interact with CA Endevor through a local command-line interface. You can control CA Endevor
               application lifecycle actions, allowing easy scripting from off-platform CI/CD pipelines.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-endevor-scm.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-endevor-scm.html
             stock_ticker: AVGO
             logo: omp_catechnologies-caendevor.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -373,7 +373,7 @@ landscape:
               The CA File Master™ Plus Plug-in for Zowe CLI brings advanced file management and data manipulation functionality to the CLI. Control functions
               that CLI can invoke include copying, renaming and deleting files, and populating files with data.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-file-master-plus.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-file-master-plus.html
             stock_ticker: AVGO
             logo: omp_catechnologies-cafilemasterplus.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -383,7 +383,7 @@ landscape:
               The CA OPS/MVS® Plug-in for Zowe CLI lets you to interact with CA OPS/MVS automation elements. The features in the plug-in enable efficient
               automation and resource management from the CLI.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-ops-mvs.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-ops-mvs.html
             stock_ticker: AVGO
             logo: omp_catechnologies-caopsmvs.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -393,7 +393,7 @@ landscape:
               The CA Secure Credential Store Plug-in for Zowe CLI lets you store your credentials securely in the default credential manager of your operating
               system.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-secure-credential-store.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-secure-credential-store.html
             stock_ticker: AVGO
             logo: omp_catechnologies-casecurecredentialstore.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -403,7 +403,7 @@ landscape:
               The CA z/OS Extended Files Plug-in for Zowe CLI lets application developers extend the CLI to support data set management functionality. For
               example, copying the contents of a data set and downloading data sets that match a DSLEVEL pattern.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-files.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-files.html
             stock_ticker: AVGO
             logo: omp_catechnologies-cazosextendedfiles.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -413,7 +413,7 @@ landscape:
               The CA z/OS Extended Jobs Plug-in for Zowe CLI lets application developers extend the CLI to support additional z/OS job creation and job
               management functionality. For example, viewing all spool content and deleting multiple jobs in the OUTPUT status.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-jobs.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-jobs.html
             stock_ticker: AVGO
             logo: omp_catechnologies-cazosextendedjobs.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'

--- a/landscape.yml
+++ b/landscape.yml
@@ -363,7 +363,7 @@ landscape:
               The CA Endevor® SCM Plug-in for Zowe CLI lets you interact with CA Endevor through a local command-line interface. You can control CA Endevor
               application lifecycle actions, allowing easy scripting from off-platform CI/CD pipelines.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-endevor-scm.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-endevor-scm.html
             stock_ticker: AVGO
             logo: omp_catechnologies-caendevor.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -373,7 +373,7 @@ landscape:
               The CA File Master™ Plus Plug-in for Zowe CLI brings advanced file management and data manipulation functionality to the CLI. Control functions
               that CLI can invoke include copying, renaming and deleting files, and populating files with data.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-file-master-plus.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-file-master-plus.html
             stock_ticker: AVGO
             logo: omp_catechnologies-cafilemasterplus.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -383,7 +383,7 @@ landscape:
               The CA OPS/MVS® Plug-in for Zowe CLI lets you to interact with CA OPS/MVS automation elements. The features in the plug-in enable efficient
               automation and resource management from the CLI.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-ops-mvs.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-ca-ops-mvs.html
             stock_ticker: AVGO
             logo: omp_catechnologies-caopsmvs.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -393,7 +393,7 @@ landscape:
               The CA Secure Credential Store Plug-in for Zowe CLI lets you store your credentials securely in the default credential manager of your operating
               system.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-secure-credential-store.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-secure-credential-store.html
             stock_ticker: AVGO
             logo: omp_catechnologies-casecurecredentialstore.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -403,7 +403,7 @@ landscape:
               The CA z/OS Extended Files Plug-in for Zowe CLI lets application developers extend the CLI to support data set management functionality. For
               example, copying the contents of a data set and downloading data sets that match a DSLEVEL pattern.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-files.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-files.html
             stock_ticker: AVGO
             logo: omp_catechnologies-cazosextendedfiles.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'
@@ -413,7 +413,7 @@ landscape:
               The CA z/OS Extended Jobs Plug-in for Zowe CLI lets application developers extend the CLI to support additional z/OS job creation and job
               management functionality. For example, viewing all spool content and deleting multiple jobs in the OUTPUT status.
             homepage_url: >-
-              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/2-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-jobs.html
+              http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/ca-brightside-command-line-interface-cli/available-cli-plug-ins/ca-brightside-plug-in-for-z-os-extended-jobs.html
             stock_ticker: AVGO
             logo: omp_catechnologies-cazosextendedjobs.svg
             crunchbase: 'https://www.crunchbase.com/organization/broadcom'


### PR DESCRIPTION
Updated URLs for CA Endevor SCM, CA OPS/MVS, CA FileMaster Plus, CA z/OS Extended-Jobs, CA z/OS Extended, and Secure Credential Store plug-ins for Zowe CLI. 