### PR TITLE
Moving GeneverERS under z/OS instead of other

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -218,6 +218,14 @@ landscape:
             repo_url: https://github.com/walmartlabs/zUID
             logo: zuid.svg
             crunchbase: https://www.crunchbase.com/organization/walmart-labs
+          - item:
+            name: GenevaERS
+            homepage_url: https://genevaers.org
+            project: incubating
+            repo_url: https://github.com/genevaers/community
+            project_org: https://github.com/genevaers
+            logo: https://raw.githubusercontent.com/openmainframeproject/artwork/master/projects/genevaers/genevaers-color.svg
+            crunchbase: https://www.crunchbase.com/organization/open-mainframe-project
       - subcategory:
         name: Development Tools
         items:
@@ -309,14 +317,6 @@ landscape:
             repo_url: https://github.com/trothr/ductwork
             logo: ductwork.svg
             crunchbase: https://www.crunchbase.com/organization/la-casita
-          - item:
-            name: GenevaERS
-            homepage_url: https://genevaers.org
-            project: incubating
-            repo_url: https://github.com/genevaers/community
-            project_org: https://github.com/genevaers
-            logo: https://raw.githubusercontent.com/openmainframeproject/artwork/master/projects/genevaers/genevaers-color.svg
-            crunchbase: https://www.crunchbase.com/organization/open-mainframe-project
           - item:
             name: Software Discovery Tool
             homepage_url: https://github.com/openmainframeproject/software-discovery-tool

--- a/settings.yml
+++ b/settings.yml
@@ -124,7 +124,7 @@ big_picture:
         category: Projects
         rows: 6
         width: 800
-        height: 225
+        height: 300
         top: 0
         left: 0
         color: rgb(37,81,209)
@@ -133,7 +133,7 @@ big_picture:
         category: Zowe Conformant
         rows: 6
         width: 1100
-        top: 245
+        top: 325
         height: 200
         left: 0
         color: rgb(79,121,13)


### PR DESCRIPTION
Signed-off-by: SaPeresi <67481368+SaPeresi@users.noreply.github.com>
GenevaERS is a z/OS product so should be under that heading in the landscape. 