### PR TITLE
Make Databases box larger in Open Source Ecosystem landscape

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -194,8 +194,8 @@ big_picture:
         category: Networking and Monitoring
         rows: 3
         width: 200
-        height: 140
-        top: 310
+        height: 160
+        top: 290
         left: 0
         color: rgb(19,105,73)
         fit_width: true
@@ -230,8 +230,8 @@ big_picture:
         category: Middleware
         rows: 3
         width: 200
-        height: 140
-        top: 310
+        height: 160
+        top: 290
         left: 630
         color: rgb(19,105,73)
         fit_width: true
@@ -248,8 +248,8 @@ big_picture:
         category: Databases
         rows: 3
         width: 200
-        height: 140
-        top: 310
+        height: 160
+        top: 290
         left: 840
         color: rgb(19,105,73)
         fit_width: true


### PR DESCRIPTION
The Databases box in the Open Source Ecosystem is too small:

![Screenshot 2021-10-27 at 15 21 13](https://user-images.githubusercontent.com/16135423/139073994-d77281a1-bc40-4978-a994-5dd230c81439.png)

I made it larger:

![Screenshot 2021-10-27 at 15 22 13](https://user-images.githubusercontent.com/16135423/139074115-d23d3ebf-9ff0-4e14-8001-536d6783c69f.png)

